### PR TITLE
chore: including lint commmand in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "babel-node app.js",
     "watch": "nodemon --exec 'npm start'",
     "lint": "semistandard",
-    "test": "npm run test:unit && npm run test:integration",
+    "test": "npm run lint && npm run test:unit && npm run test:integration",
     "test:unit": "mocha -r should --compilers js:babel-register 'src/**/*.spec.js'",
     "test:integration": "mocha -r should --compilers js:babel-register 'test/**/*.js'"
   },


### PR DESCRIPTION
`npm test` is the default way to test our code. Anybody who ever has touched node code does know about `npm test` while `npm run lint` is non standard. Let's make newcomers' life easy.